### PR TITLE
now use legacy api backend

### DIFF
--- a/assets/scripts/users.js
+++ b/assets/scripts/users.js
@@ -49,7 +49,7 @@ const Functions = {
 
 		let data;
 		try {
-			const response = await fetch(`https://backend.camellia.wiki/${url}`, { headers, method, body});
+			const response = await fetch(`https://backend-legacy.camellia.wiki/${url}`, { headers, method, body});
 			if (!response.ok || response.status != 200) {
 				throw new Error(`Failed to communicate to API (response was ${response.ok ? "OK" : "NOT OK"}; status ${response.status})!`);
 			};


### PR DESCRIPTION
sanity sakes, we are beginning to change routes on the new backend for the new wiki, which is affecting old wiki, so to keep it working for now, this is what we're doing.